### PR TITLE
Unlock Secret Commanders

### DIFF
--- a/gow_co_balance_mod/assets_src/config/gameplay/commanders_secret.yaml
+++ b/gow_co_balance_mod/assets_src/config/gameplay/commanders_secret.yaml
@@ -1,0 +1,63 @@
+---
+
+#Removes the requirements to unlock Elodie, Dark Mercia, and Mercival
+#This overwrites commanders_secret.yaml; I will be looking into a method that is more friendly with mod and update compatibility
+commanders:
+  - id: elodie
+    name: character_elodie_name
+    title: character_elodie_title
+    faction: guardian
+    factionIndex: 0
+    portrait:
+      neutral: portraits/commanders/small/elodie_portrait_small.png
+      happy: portraits/commanders/small/elodie_portrait_happy.png
+      sad: portraits/commanders/small/elodie_portrait_sad.png
+    cutscenePortrait: portraits/commanders/big/elodie_portrait
+    portraitOffset: [-10, -40]
+    namePlate: ui/character_select/charlabel/charlabel_elodie.png
+    themeSong: music/elodie
+    skinColour: typeIV
+    unitClassId: commander_elodie
+    selectionSound: elodie/elodieShoutShallIPlayYouASong
+    dialogueBoxVoice: ui/dialogue/textScrollElodie
+    deathFade: false
+    deathTime: 5
+
+  - id: darkmercia
+    name: character_darkmercia_name
+    title: character_darkmercia_title
+    faction: guardian
+    factionIndex: 1
+    portrait:
+      neutral: portraits/commanders/small/darkmercia_portrait_small.png
+      happy: portraits/commanders/small/darkmercia_portrait_happy.png
+      sad: portraits/commanders/small/darkmercia_portrait_sad.png
+    cutscenePortrait: portraits/commanders/big/darkmercia_portrait
+    portraitOffset: [0, -45]
+    namePlate: ui/character_select/charlabel/charlabel_darkmercia.png
+    themeSong: music/darkmercia
+    skinColour: typeII
+    unitClassId: commander_darkmercia
+    selectionSound: darkmercia/darkmerciaShoutDarknessFalls
+    dialogueBoxVoice: ui/dialogue/textScrollDarkMercia
+    deathFade: false
+
+  - id: mercival
+    name: character_mercival_name
+    title: character_mercival_title
+    faction: cherrystone
+    factionIndex: 3
+    portrait:
+      neutral: portraits/commanders/small/mercival_portrait_small.png
+      happy: portraits/commanders/small/mercival_portrait_happy.png
+      sad: portraits/commanders/small/mercival_portrait_sad.png
+      extra: portraits/commanders/small/mercival_portrait_ghost.png
+    cutscenePortrait: portraits/commanders/big/mercival_portrait
+    namePlate: ui/character_select/charlabel/charlabel_mercival.png
+    themeSong: music/mercival
+    skinColour: typeII
+    unitClassId: commander_mercival
+    selectionSound: mercival/mercivalShoutIAmWithYou
+    dialogueBoxVoice: ui/dialogue/textScrollMercival
+
+...


### PR DESCRIPTION
Removes the requirements to unlock Elodie, Dark Mercia, and Mercival for a fair playing field.
This overwrites commanders_secret.yaml; I will be looking into a method that is more friendly with mod and update compatibility